### PR TITLE
docs: отделить команды от вывода

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 ### Проверка последних версий зависимостей проекта
 
 ```bash
-$ depos check
+depos check
+```
+
+```bash
 Проверка зависимостей в path/to/packagedef
 
  1connector         2.3.1 → 2.3.3
@@ -26,7 +29,10 @@ $ depos check
 > Убедитесь, что файл `packagedef` находится в системе контроля версий, и все изменения зафиксированы. Это действие перезапишет ваш файл.
 
 ```bash
-$ depos upgrade
+depos upgrade
+```
+
+```bash
 Обновление зависимостей в path/to/packagedef
 
  1connector         2.3.1 → 2.3.3


### PR DESCRIPTION
При текущей реализации доки не удобно копировать саму команду